### PR TITLE
Algorithm_second 3주차 [한종욱]

### DIFF
--- a/Ukjong/week03/[BOJ-1719] 택배.java
+++ b/Ukjong/week03/[BOJ-1719] 택배.java
@@ -1,0 +1,135 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    // 입출력을 위한 BufferedReader, BufferedWriter
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    private static final int INF = 10000010;  // 무한대 값 (충분히 큰 수)
+    private static List<Node>[] graph;        // 인접 리스트로 그래프 표현
+    private static int[] dist;                // 최단 거리 배열
+    private static int[][] path;              // 경로 테이블 (i에서 j로 가는 첫 번째 경유지)
+    private static int N, M;                  // N: 집하장 개수, M: 간선 개수
+
+    public static void main(String[] args) throws IOException {
+        init();  // 초기화
+
+        // 모든 집하장에서 다른 모든 집하장으로의 최단 경로 계산
+        for (int i = 1; i <= N; i++) {
+            dijkstra(i);  // i번 집하장을 시작점으로 다익스트라 실행
+        }
+
+        // 경로 테이블 출력
+        for (int i = 1; i <= N; i++) {
+            for (int j = 1; j <= N; j++) {
+                if (path[i][j] == 0) {
+                    bw.write("-" + " ");  // 자기 자신으로 가는 경우는 "-"
+                }
+                else {
+                    bw.write(path[i][j] + " ");  // i에서 j로 가는 첫 번째 경유지
+                }
+            }
+            bw.write("\n");
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    // 입력 받기 및 초기화
+    public static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());  // 집하장 개수
+        M = Integer.parseInt(st.nextToken());  // 간선 개수
+
+        // 배열 및 리스트 초기화
+        graph = new List[N + 1];  // 1번부터 N번까지 사용
+        dist = new int[N + 1];    // 최단 거리 배열
+        path = new int[N + 1][N + 1];  // 경로 테이블
+
+        // 각 집하장의 인접 리스트 초기화
+        for (int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        // 간선 정보 입력
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());  // 시작 집하장
+            int v = Integer.parseInt(st.nextToken());  // 도착 집하장
+            int w = Integer.parseInt(st.nextToken());  // 비용
+
+            // 양방향 간선 추가 (무방향 그래프)
+            graph[u].add(new Node(v, w));
+            graph[v].add(new Node(u, w));
+        }
+    }
+
+    // 다익스트라 알고리즘으로 start에서 모든 정점까지의 최단 경로 계산
+    private static void dijkstra(int start) {
+        // 비용 기준으로 최소 힙 사용
+        PriorityQueue<Node> pq = new PriorityQueue<>((o1, o2) -> Integer.compare(o1.cost, o2.cost));
+
+        // 거리 배열 초기화 (무한대로 설정)
+        Arrays.fill(dist, INF);
+        dist[start] = 0;  // 시작점의 거리는 0
+
+        // 시작점을 우선순위 큐에 추가
+        pq.add(new Node(start, dist[start]));
+
+        while (!pq.isEmpty()) {
+            Node current = pq.poll();  // 현재 가장 비용이 적은 노드
+
+            // 이미 처리된 노드라면 건너뛰기 (중복 처리 방지)
+            if (current.cost > dist[current.dest]) continue;
+
+            // 현재 노드와 연결된 모든 인접 노드 확인
+            for (Node next : graph[current.dest]) {
+                int nCost = current.cost + next.cost;  // 새로운 경로의 비용
+
+                // 더 짧은 경로를 발견했다면
+                if (nCost < dist[next.dest]) {
+                    dist[next.dest] = nCost;  // 최단 거리 갱신
+
+                    // 경로 추적: 시작점에서 목적지로 가는 첫 번째 경유지 저장
+                    if (current.path == 0) {
+                        // 시작점에서 직접 연결된 경우
+                        // start -> next.dest로 바로 가는 경우
+                        path[start][next.dest] = next.dest;
+                        pq.add(new Node(next.dest, nCost, next.dest));
+                    }
+                    else {
+                        // 경유지를 거쳐서 가는 경우
+                        // start -> current.path -> ... -> next.dest
+                        // 첫 번째 경유지는 current.path와 동일
+                        path[start][next.dest] = current.path;
+                        pq.add(new Node(next.dest, nCost, current.path));
+                    }
+                }
+            }
+        }
+    }
+
+    // 노드 클래스: 목적지, 비용, 경로 정보를 담음
+    static class Node{
+        int dest;  // 목적지 집하장 번호
+        int cost;  // 해당 목적지까지의 비용
+        int path;  // 시작점에서 이 노드로 가는 첫 번째 경유지
+
+        // 기본 생성자: 경로 정보 없이 노드 생성 (그래프 구성용)
+        public Node(int dest, int cost) {
+            this.dest = dest;
+            this.cost = cost;
+            this.path = 0;  // 경로 정보 없음
+        }
+
+        // 경로 정보 포함 생성자: 다익스트라 실행 중 사용
+        public Node(int dest, int cost, int path) {
+            this.dest = dest;
+            this.cost = cost;
+            this.path = path;  // 첫 번째 경유지 정보
+        }
+    }
+}

--- a/Ukjong/week03/[BOJ-20058] 마법사 상어와 파이어스톰.java
+++ b/Ukjong/week03/[BOJ-20058] 마법사 상어와 파이어스톰.java
@@ -1,0 +1,176 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    // 입출력을 위한 BufferedReader, BufferedWriter
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    // 상하좌우 이동을 위한 방향 배열
+    private static int[] dx = {1, 0, -1, 0};  // 하, 우, 상, 좌
+    private static int[] dy = {0, 1, 0, -1};
+
+    private static int[][] arr;           // 얼음의 양을 저장하는 2차원 배열
+    private static boolean[][] visited;   // BFS에서 방문 체크용 배열
+    private static int N, Q, length;      // N: 격자 크기 지수, Q: 파이어스톰 시전 횟수, length: 실제 격자 크기(2^N)
+
+    public static void main(String[] args) throws IOException {
+        init();  // 입력 처리 및 파이어스톰 시전
+
+        // 결과 계산
+        int totalIce = countIce();        // 남은 얼음의 총합
+        int largestIce = 0;               // 가장 큰 얼음 덩어리의 크기
+
+        // 모든 칸을 확인하여 가장 큰 연결된 얼음 덩어리 찾기
+        for (int i = 0; i < arr.length; i++) {
+            for (int j = 0; j < arr.length; j++) {
+                // 얼음이 있고 아직 방문하지 않은 칸이면 BFS 시작
+                if (arr[i][j] > 0 && !visited[i][j]) {
+                    int n = BFS(i, j);  // 해당 덩어리의 크기 계산
+                    largestIce = Math.max(largestIce, n);
+                }
+            }
+        }
+
+        // 결과 출력: 총 얼음의 양, 가장 큰 덩어리의 크기
+        bw.write(totalIce + "\n" + largestIce + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    // 입력 처리 및 초기화, 파이어스톰 시전
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());  // 격자 크기는 2^N × 2^N
+        Q = Integer.parseInt(st.nextToken());  // 파이어스톰 시전 횟수
+        length = (int) Math.pow(2, N);         // 실제 격자 크기 계산
+
+        // 배열 초기화
+        arr = new int[length][length];         // 얼음 배열
+        visited = new boolean[length][length]; // 방문 체크 배열
+
+        // 초기 얼음 상태 입력
+        for (int i = 0; i < length; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < length; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        // 파이어스톰 시전
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < Q; i++) {
+            int l = (int) Math.pow(2, Integer.parseInt(st.nextToken()));  // 2^L 크기의 부분 격자
+            rotate(l);  // 1단계: 부분 격자들을 시계방향으로 90도 회전
+            melt();     // 2단계: 얼음 녹이기
+        }
+    }
+
+    // 1단계: 격자를 L×L 크기의 부분 격자로 나누어 각각을 시계방향 90도 회전
+    private static void rotate(int L) {
+        // 격자를 L×L 크기로 나누어 각 부분격자마다 회전 수행
+        for (int i = 0; i < length; i += L) {
+            for (int j = 0; j < length; j += L) {
+                rotate(i, j, L);  // (i,j)를 왼쪽 위 모서리로 하는 L×L 격자 회전
+            }
+        }
+    }
+
+    // 특정 위치 (x, y)에서 시작하는 L×L 부분격자를 시계방향 90도 회전
+    private static void rotate(int x, int y, int L) {
+        int[][] temp = new int[L][L];  // 임시 배열
+
+        // 시계방향 90도 회전: (i, j) → (j, L-1-i)
+        for (int i = 0; i < L; i++) {
+            for (int j = 0; j < L; j++) {
+                temp[j][L - 1 - i] = arr[x + i][y + j];
+            }
+        }
+
+        // 회전된 결과를 원래 배열에 복사
+        for (int i = x; i < x + L; i++) {
+            for (int j = y; j < y + L; j++) {
+                arr[i][j] = temp[i - x][j - y];
+            }
+        }
+    }
+
+    // 2단계: 얼음 녹이기 - 인접한 칸 중 얼음이 있는 칸이 2개 이하면 얼음 1 감소
+    private static void melt() {
+        List<int[]> temp = new ArrayList<>();  // 녹을 얼음의 위치를 저장
+
+        // 모든 칸을 확인하여 녹을 얼음 찾기
+        for (int i = 0; i < length; i++) {
+            for (int j = 0; j < length; j++) {
+                int count = 0;  // 인접한 칸 중 얼음이 없거나 범위를 벗어난 칸의 개수
+
+                // 상하좌우 4방향 확인
+                for (int k = 0; k < 4; k++) {
+                    int nx = i + dx[k];
+                    int ny = j + dy[k];
+
+                    // 범위를 벗어나거나 얼음이 없는 칸이면 count 증가
+                    if (OOB(nx, ny) || arr[nx][ny] == 0) {
+                        count++;
+                    }
+                }
+
+                // 얼음이 있는 칸 중에서 인접한 얼음이 있는 칸이 2개 이하인 경우
+                // (즉, 얼음이 없거나 범위를 벗어난 칸이 2개 이상인 경우)
+                if (count > 1 && arr[i][j] > 0) {
+                    temp.add(new int[]{i, j});  // 녹을 위치 저장
+                }
+            }
+        }
+
+        // 저장된 위치의 얼음을 1씩 감소
+        for (int[] element : temp) {
+            arr[element[0]][element[1]]--;
+        }
+    }
+
+    // 남은 얼음의 총합 계산
+    private static int countIce() {
+        int result = 0;
+        for (int i = 0; i < length; i++) {
+            for (int j = 0; j < length; j++) {
+                result += arr[i][j];
+            }
+        }
+        return result;
+    }
+
+    // BFS를 사용하여 연결된 얼음 덩어리의 크기 계산
+    private static int BFS(int x, int y) {
+        Queue<int[]> q = new ArrayDeque<>();
+        int result = 1;           // 현재 위치도 포함하므로 1부터 시작
+        visited[x][y] = true;     // 시작 위치 방문 처리
+        q.add(new int[]{x, y});   // 큐에 시작 위치 추가
+
+        while (!q.isEmpty()) {
+            int[] current = q.poll();  // 현재 위치
+
+            // 상하좌우 4방향 탐색
+            for (int i = 0; i < 4; i++) {
+                int nx = current[0] + dx[i];
+                int ny = current[1] + dy[i];
+
+                // 범위를 벗어나거나, 얼음이 없거나, 이미 방문한 경우 건너뛰기
+                if (OOB(nx, ny) || arr[nx][ny] == 0 || visited[nx][ny]) continue;
+
+                // 새로운 얼음 발견
+                visited[nx][ny] = true;  // 방문 처리
+                result++;                // 덩어리 크기 증가
+                q.add(new int[]{nx, ny}); // 큐에 추가하여 계속 탐색
+            }
+        }
+
+        return result;  // 연결된 얼음 덩어리의 크기 반환
+    }
+
+    // 좌표가 격자 범위를 벗어났는지 확인하는 함수
+    private static boolean OOB(int nx, int ny) {
+        return nx < 0 || nx > length - 1 || ny < 0 || ny > length - 1;
+    }
+}

--- a/Ukjong/week03/[BOJ-20955] 민서의 응급 수술.java
+++ b/Ukjong/week03/[BOJ-20955] 민서의 응급 수술.java
@@ -1,0 +1,97 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    // 입출력을 위한 BufferedReader, BufferedWriter
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    private static int[] uf;    // Union-Find의 부모 배열
+    private static int[] size;  // 각 집합의 크기 (Union by Size 최적화용)
+    private static int N, M, answer;  // N: 뉴런 개수, M: 시냅스 개수, answer: 최소 수술 횟수
+
+    public static void main(String[] args) throws IOException {
+        init();  // 입력 처리 및 계산
+        bw.write(answer + "\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    // 입력 처리 및 핵심 로직
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());  // 뉴런의 개수
+        M = Integer.parseInt(st.nextToken());  // 시냅스의 개수
+
+        // Union-Find 자료구조 초기화
+        uf = new int[N + 1];    // 부모 배열
+        size = new int[N + 1];  // 각 집합의 원소 개수
+
+        // 초기화: 각 뉴런을 독립적인 집합으로 설정
+        for (int i = 1; i <= N; i++) {
+            uf[i] = i;      // 자기 자신을 부모로 설정
+            size[i] = 1;    // 초기 집합 크기는 1
+        }
+
+        int cycleEdges = 0;  // 사이클을 형성하는 간선의 개수 (제거해야 할 간선)
+        int validEdges = 0;  // 트리 구조에 포함되는 유효한 간선의 개수
+
+        // 모든 시냅스(간선) 처리
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());  // 시냅스로 연결된 뉴런1
+            int v = Integer.parseInt(st.nextToken());  // 시냅스로 연결된 뉴런2
+
+            // 두 뉴런의 루트(대표) 찾기
+            int U = find(u);
+            int V = find(v);
+
+            if (U == V) {
+                // 같은 집합에 속한 뉴런들을 연결하는 간선
+                // → 사이클을 형성하므로 제거해야 함
+                cycleEdges++;
+            } else {
+                // 다른 집합에 속한 뉴런들을 연결하는 간선
+                // → 두 집합을 합치고, 트리 구조에 포함됨
+                union(u, v);
+                validEdges++;
+            }
+        }
+
+        // 연결된 컴포넌트(집합)의 개수 계산
+        Set<Integer> roots = new HashSet<>();
+        for (int i = 1; i <= N; i++) {
+            roots.add(find(i));  // 각 뉴런의 루트를 Set에 추가
+        }
+
+        // 최소 수술 횟수 계산
+        // = 제거할 간선 수 + 추가할 간선 수
+        // = cycleEdges + (컴포넌트 개수 - 1)
+        answer = cycleEdges + roots.size() - 1;
+    }
+
+    // Union 연산: 두 집합을 합치기 (Union by Size 최적화)
+    private static void union(int x, int y) {
+        int X = find(x);  // x의 루트 찾기
+        int Y = find(y);  // y의 루트 찾기
+
+        // 크기가 작은 트리를 큰 트리 아래에 붙이기 (Union by Size)
+        if (size[X] < size[Y]) {
+            uf[X] = Y;          // X의 부모를 Y로 설정
+            size[Y] += size[X]; // Y 집합의 크기 증가
+        } else {
+            uf[Y] = X;          // Y의 부모를 X로 설정
+            size[X] += size[Y]; // X 집합의 크기 증가
+        }
+    }
+
+    // Find 연산: 원소 x가 속한 집합의 루트 찾기 (경로 압축 최적화)
+    private static int find(int x) {
+        if (uf[x] == x) return x;  // 루트 노드인 경우
+
+        // 경로 압축: 재귀적으로 루트를 찾으면서
+        // 중간 노드들의 부모를 루트로 직접 연결
+        return uf[x] = find(uf[x]);
+    }
+}

--- a/Ukjong/week03/[BOJ-2293] 동전 1.java
+++ b/Ukjong/week03/[BOJ-2293] 동전 1.java
@@ -1,0 +1,53 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    // 입출력을 위한 BufferedReader, BufferedWriter
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    private static int[] dp;  // dp[i] = 금액 i를 만드는 경우의 수
+    private static int N, K;  // N: 동전 종류의 개수, K: 목표 금액
+
+    public static void main(String[] args) throws IOException {
+        init();  // 입력 처리 및 DP 계산
+        bw.write(dp[K] + "\n");  // 목표 금액 K를 만드는 경우의 수 출력
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    // 입력 처리 및 동적 프로그래밍으로 경우의 수 계산
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());  // 동전의 종류 개수
+        K = Integer.parseInt(st.nextToken());  // 만들려는 목표 금액
+
+        // DP 배열 초기화
+        // dp[i] = 금액 i를 만드는 방법의 수
+        dp = new int[K + 1];
+
+        // 각 동전 종류에 대해 DP 테이블 업데이트
+        for (int i = 0; i < N; i++) {
+            int coin = Integer.parseInt(br.readLine());  // 현재 동전의 가치
+
+            // 금액 0부터 K까지 각각에 대해 현재 동전을 사용했을 때의 경우의 수 계산
+            for (int j = 0; j <= K; j++) {
+                if (j == 0) {
+                    // 기저 조건: 금액 0을 만드는 방법은 항상 1가지 (아무 동전도 사용하지 않기)
+                    dp[j] = 1;
+                } else if (j >= coin) {
+                    // 현재 금액 j가 동전의 가치 이상인 경우
+                    // 현재 동전을 사용해서 금액 j를 만들 수 있음
+                    //
+                    // dp[j] += dp[j - coin]의 의미:
+                    // - 기존에 금액 j를 만드는 방법의 수: dp[j]
+                    // - 현재 동전을 하나 사용해서 금액 j를 만드는 방법의 수: dp[j - coin]
+                    // - 이 둘을 합쳐서 총 경우의 수 갱신
+                    dp[j] += dp[j - coin];
+                }
+                // j < coin인 경우: 현재 동전으로는 금액 j를 만들 수 없으므로 변화 없음
+            }
+        }
+    }
+}

--- a/Ukjong/week03/[BOJ-4991] 로봇 청소기.java
+++ b/Ukjong/week03/[BOJ-4991] 로봇 청소기.java
@@ -1,0 +1,125 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    // 입출력을 위한 BufferedReader, BufferedWriter
+    private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    // 상하좌우 이동을 위한 방향 배열
+    private static final int[] dx = {1, 0, -1, 0};  // 하, 우, 상, 좌
+    private static final int[] dy = {0, 1, 0, -1};
+
+    private static char[][] map;        // 방의 지도
+    private static List<int[]> dust;    // 먼지 위치들을 저장하는 리스트
+    private static boolean[][][] visited;  // 방문 체크 배열 [x][y][먼지수집상태]
+    private static int[] start;         // 로봇 청소기의 시작 위치
+    private static int w, h;            // 방의 너비와 높이
+
+    public static void main(String[] args) throws IOException {
+        while (true) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            w = Integer.parseInt(st.nextToken());  // 너비
+            h = Integer.parseInt(st.nextToken());  // 높이
+
+            // 0 0 입력시 프로그램 종료
+            if (w == 0 && h == 0) break;
+
+            init();  // 초기화
+            int answer = BFS();  // BFS로 최소 이동 횟수 계산
+            bw.write(answer + "\n");
+        }
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    // 초기화 함수
+    public static void init() throws IOException {
+        start = new int[2];
+        map = new char[h][w];
+        dust = new ArrayList<>();
+
+        // 지도 입력 및 시작점, 먼지 위치 찾기
+        for (int i = 0; i < h; i++) {
+            String input = br.readLine();
+            for (int j = 0; j < w; j++) {
+                map[i][j] = input.charAt(j);
+
+                // 로봇 청소기 시작 위치
+                if (map[i][j] == 'o') {
+                    start[0] = i;
+                    start[1] = j;
+                }
+
+                // 먼지 위치를 리스트에 저장
+                if (map[i][j] == '*') {
+                    dust.add(new int[]{i, j});
+                }
+            }
+        }
+
+        // 3차원 방문 배열 초기화
+        // [x좌표][y좌표][먼지 수집 상태를 비트마스크로 표현]
+        visited = new boolean[h][w][1 << dust.size()];
+    }
+
+    // BFS를 이용한 최단 경로 탐색
+    private static int BFS() {
+        Queue<int[]> q = new ArrayDeque<>();
+
+        // 시작 위치와 먼지 수집 상태 0으로 초기화
+        visited[start[0]][start[1]][0] = true;
+        q.add(new int[]{start[0], start[1], 0, 0});  // {x, y, 먼지수집상태, 이동횟수}
+
+        while (!q.isEmpty()) {
+            int[] current = q.poll();
+
+            // 모든 먼지를 수집했다면 현재까지의 이동 횟수 반환
+            // (1 << dust.size()) - 1 은 모든 먼지를 수집한 상태의 비트마스크
+            if (current[2] == ((1 << dust.size()) - 1)) {
+                return current[3];
+            }
+
+            // 4방향으로 이동 시도
+            for (int i = 0; i < 4; i++) {
+                int nx = current[0] + dx[i];  // 다음 x 좌표
+                int ny = current[1] + dy[i];  // 다음 y 좌표
+                int nMask = current[2];       // 현재 먼지 수집 상태 복사
+
+                // 범위를 벗어나거나 가구가 있는 곳은 이동 불가
+                if (OOB(nx, ny) || map[nx][ny] == 'x') continue;
+
+                // 먼지가 있는 위치에 도달했다면
+                if (map[nx][ny] == '*') {
+                    int dustIndex = getDustIndex(nx, ny);  // 해당 먼지의 인덱스 찾기
+                    nMask |= (1 << dustIndex);  // 비트마스크에 해당 먼지 수집 표시
+                }
+
+                // 해당 위치와 먼지 수집 상태로 방문한 적이 없다면
+                if (!visited[nx][ny][nMask]) {
+                    visited[nx][ny][nMask] = true;
+                    q.add(new int[]{nx, ny, nMask, current[3] + 1});
+                }
+            }
+        }
+
+        // 모든 먼지를 수집할 수 없는 경우
+        return -1;
+    }
+
+    // 좌표가 범위를 벗어났는지 확인하는 함수
+    private static boolean OOB(int nx, int ny) {
+        return nx < 0 || nx > h - 1 || ny < 0 || ny > w - 1;
+    }
+
+    // 주어진 좌표의 먼지가 리스트에서 몇 번째 인덱스인지 찾는 함수
+    private static int getDustIndex(int nx, int ny) {
+        for (int i = 0; i < dust.size(); i++) {
+            if (nx == dust.get(i)[0] && ny == dust.get(i)[1]) {
+                return i;
+            }
+        }
+        return -1;  // 찾지 못한 경우 (실제로는 발생하지 않음)
+    }
+}


### PR DESCRIPTION
# 🚀 Algorithm_second 3주차 [한종욱]

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **로봇 청소기**
  - [x] **택배**  
  - [x] **민서의 응급 수술**
  - [x] **마법사 상어와 파이어스톰**  
  - [x] **동전 1**  
  
---

## 💡 풀이 방법
### 문제 1: 로봇 청소기

**문제 난이도**

Gold 1

**문제 유형**

- BFS

**접근 방식 및 풀이**

먼지수집상태를 저장하기 위해 visited배열을 3차원으로 선언하고, 각 먼지를 구분하기 위해 번호를 매겼습니다.
(같은 위치라도 다른 먼지 수집 상태면 다른 상태로 취급)

먼지 위치를 List에 저장하고, 시작 위치부터 BFS 방식으로 먼지를 수집하며 모두 수집할 수 있는지를 탐색합니다. 

---


### 문제 2: 택배

**문제 난이도**

Gold 3

**문제 유형**

- 다익스트라

**접근 방식 및 풀이**

Node에 dest, cost 말고도 시작점에서 이 노드로 가는 첫 번째 경유지인 path를 저장했습니다. 
시작점에서 목적지로 가는 첫 번째 경유지이면 경유지를 설정해주고, 이미 경유지를 거친 경우에는 첫 번째 경유지를 유지했습니다. 

---


### 문제 3: 민서의 응급 수술

**문제 난이도**

Gold 4

**문제 유형**

- 분리 집합

**접근 방식 및 풀이**

뉴런 정보가 들어올 때, 두 뉴런의 루트를 찾아

1. 루트가 서로 같다면 -> 사이클을 형성하므로 제거해야 함
2. 루트가 서로 다르면 -> 두 집합을 합침

1번을 통해 제거해야 할 간선의 개수를 계산합니다. 
각 뉴런의 집합의 수를 찾아 모두 트리로 만들기 위한 간선의 개수를 계산해 두 값을 더합니다. 

---


### 문제 4: 마법사 상어와 파이어스톰

**문제 난이도**

Gold 3

**문제 유형**

- 구현
- BFS

**접근 방식 및 풀이**

1단계, 2단계로 나눠서 풀었습니다. 
1. LxL 크기의 부분 격자로 나누어 시계방향으로 90도 회전하는 것
2. 얼음 녹이기 - 인접한 칸 중 얼음이 있는 칸이 2개 이하면 얼음 1 감소

남은 얼음의 총합은 이중 for문으로, 가장 큰 얼음 덩어리는 BFS로 계산했습니다. 

---


### 문제 5: 동전 1

**문제 난이도**

Gold 4

**문제 유형**

- DP

**접근 방식 및 풀이**

점화식은 `dp[j]+=dp[j - coin]`입니다. 
동전별 -> 금액별 순서로 처리해 중복 계산을 방지합니다. 